### PR TITLE
[FIX] remove bad dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
+      - python3-lasso  # because there is not pypi package
 
 env:
   global:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,3 @@ email_validator
 python-u2flib-server
 # password_security
 zxcvbn
-# auth_saml
-lasso


### PR DESCRIPTION
`lasso` on `external_dependencies` is wrong, https://pypi.org/project/lasso/ dont implement any thing about saml.

`python3-lasso` comes from https://ubuntuupdates.org/package/core/bionic/universe/updates/python3-lasso

We are using `apt_requirements.txt` https://git.vauxoo.com/vauxoo/sbd/-/merge_requests/168/diffs#128ec923d1bd466fa8a7c257492af6b47aa3a49b_0_1 to solve it. 