### PR TITLE
[FIX] password_security: adjust validations in installation.

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -48,7 +48,8 @@ class ResUsers(models.Model):
 
     def _check_password_policy(self, passwords):
         result = super(ResUsers, self)._check_password_policy(passwords)
-
+        if self.env.context.get("install_module"):
+            return result
         for password in passwords:
             if not password:
                 continue


### PR DESCRIPTION
When password security is in the process of installation. Enable password verification on already installed modules. Stopping the loading of data affecting the complete installation. This is fixed here to avoid password verification in the installation.